### PR TITLE
fingerprint template as a global property

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ m2sys-biometrics.customKey - The m2sys server CustomKey<br/>
 m2sys-biometrics.locationID - The m2sys server location ID<br/>
 m2sys-biometrics.server.password - The m2sys server password<br/>
 m2sys-biometrics.server.url - The m2sys server url<br/>
+m2sys-biometrics.device.name - The m2sys fingerprint scanning device name<br/>
 m2sys-biometrics.server.user - The m2sys server username<br/>
 m2sys-biometrics.local-service.url - The URL to the SOAP service of the local (local to the clinic) M2Sys BioPlugin Server.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Currently the module uses the **V8** version of the service.
 
 ## Configuration variables
 
+### Template if no scanner exists
+
+If no fingerprint scanner exists, simulations may be performed using a pre-loaded fingerprint template to be stored as a global property:
+m2sys-biometrics.server.constTestTemplate - String representation of the fingerprint template
+
 ### Local variables
 m2sys-biometrics.accessPointID - The m2sys server AccessPointID<br/>
 m2sys-biometrics.accessPointMap - A map of IP addresses to Access Point IDs. Has format of IP1:AccessPointID1;IP2:AccessPointID2;...

--- a/api/src/main/java/org/openmrs/module/m2sysbiometrics/M2SysBiometricsConstants.java
+++ b/api/src/main/java/org/openmrs/module/m2sysbiometrics/M2SysBiometricsConstants.java
@@ -7,6 +7,8 @@ public final class M2SysBiometricsConstants {
 
     public static final String M2SYS_CLOUD_SCANR_URL = "m2sys-biometrics.server.url";
 
+    public static final String M2SYS_CAPTURE_DEVICE_NAME = "m2sys-biometrics.device.name";
+
    // public static final String M2SYS_CLOUD_SCANR_USERNAME = "m2sys-biometrics.server.user";
 
    // public static final String M2SYS_CLOUD_SCANR_PASSWORD = "m2sys-biometrics.server.password";

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -140,6 +140,14 @@
     </globalProperty>
 
     <globalProperty>
+        <property>${project.parent.artifactId}.device.name</property>
+        <defaultValue>DigitalPersona</defaultValue>
+        <description>
+            The m2sys fingerprint scanning device name.
+        </description>
+    </globalProperty>
+
+    <globalProperty>
         <property>${project.parent.artifactId}.local-service.url</property>
         <defaultValue></defaultValue>
         <description>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -164,6 +164,14 @@
     </globalProperty>
 
     <globalProperty>
+        <property>${project.parent.artifactId}.constTestTemplate</property>
+        <defaultValue></defaultValue>
+        <description>
+            A default test fingerprint template for instances when the fingerprint scanner is not available.
+        </description>
+    </globalProperty>
+
+    <globalProperty>
         <property>${project.parent.artifactId}.accessPointMap</property>
         <defaultValue></defaultValue>
         <description>


### PR DESCRIPTION
Configure fingerprint template as a global property to bypass scanning in cases where there is no fingerprint scanner locally. To be used for test purposes, otherwise should be empty